### PR TITLE
Switching to gxargs when on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Group extracted images by face:
 
 The /faces directory now contains images of all images recognized from the videos, and faces.csv is a listing of each face image file and the unique face pictured.
 
+### OS/X
+
+On OS/X, you will need to install GNU xargs, as the version of xargs built into OS/X is lacking some needed command-line options.  The recommended way to do this is via the Homebrew package `findutils`:
+```
+brew install findutils
+```
+
 ## Advanced usage
 
 It’s made up of a few scripts. Here’s more detailed usage details:

--- a/extract-faces
+++ b/extract-faces
@@ -49,7 +49,16 @@ for i in range(len(videos)):
 
 file.close()
 
-scmd = 'xargs -a {file} -I {{}} -n1 -P{processes} sh -c "{script} {{}} || true"'.format(
+xargs = 'xargs'
+
+import platform
+if platform.system() == 'Darwin':
+  # On OSX, use gxargs instead of the default OSX xargs (which doesn't support the same parameters).
+  # Make sure to install gxargs via Homebrew:
+  #   brew install findutils
+  xargs = 'gxargs'
+
+scmd = xargs + ' -a {file} -I {{}} -n1 -P{processes} sh -c "{script} {{}} || true"'.format(
          file=tf.name, processes=args.processes
        , script=os.path.join(str(pathlib.Path(__file__).parent.absolute()), 'extract-faces-from-video')
        )


### PR DESCRIPTION
Resolves Issue #1 by using `gxargs` when on OS/X.